### PR TITLE
Upgrade org.takes to 1.26.0 and qulice to 0.25.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>org.takes</groupId>
       <artifactId>takes</artifactId>
-      <version>1.25.0</version>
+      <version>1.26.0</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi.incubator</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.25.1</version>
+            <version>0.25.2</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/main/resources/webapp/.*</exclude>

--- a/src/main/java/co/stateful/core/DefaultUser.java
+++ b/src/main/java/co/stateful/core/DefaultUser.java
@@ -46,17 +46,17 @@ final class DefaultUser implements User {
     /**
      * Table name.
      */
-    public static final String TOKENS = "tokens";
+    static final String TOKENS = "tokens";
 
     /**
      * Hash.
      */
-    public static final String HASH = "urn";
+    static final String HASH = "urn";
 
     /**
      * Token attribute.
      */
-    public static final String ATTR_TOKEN = "token";
+    static final String ATTR_TOKEN = "token";
 
     /**
      * Name of the user.

--- a/src/main/java/co/stateful/core/DyCounters.java
+++ b/src/main/java/co/stateful/core/DyCounters.java
@@ -37,22 +37,22 @@ final class DyCounters implements Counters {
     /**
      * Table name.
      */
-    public static final String TBL = "counters";
+    static final String TBL = "counters";
 
     /**
      * Hash.
      */
-    public static final String HASH = "urn";
+    static final String HASH = "urn";
 
     /**
      * Range.
      */
-    public static final String RANGE = "name";
+    static final String RANGE = "name";
 
     /**
      * Value attribute.
      */
-    public static final String ATTR_VALUE = "value";
+    static final String ATTR_VALUE = "value";
 
     /**
      * Dynamo table.

--- a/src/main/java/co/stateful/core/DyLocks.java
+++ b/src/main/java/co/stateful/core/DyLocks.java
@@ -39,22 +39,22 @@ final class DyLocks implements Locks {
     /**
      * Table name.
      */
-    public static final String TBL = "locks";
+    static final String TBL = "locks";
 
     /**
      * Hash.
      */
-    public static final String HASH = "urn";
+    static final String HASH = "urn";
 
     /**
      * Range.
      */
-    public static final String RANGE = "name";
+    static final String RANGE = "name";
 
     /**
      * Label.
      */
-    public static final String ATTR_LABEL = "label";
+    static final String ATTR_LABEL = "label";
 
     /**
      * Dynamo table.

--- a/src/main/java/co/stateful/web/TkAppAuth.java
+++ b/src/main/java/co/stateful/web/TkAppAuth.java
@@ -6,6 +6,8 @@ package co.stateful.web;
 
 import co.stateful.spi.Base;
 import com.jcabi.manifests.Manifests;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
@@ -66,11 +68,15 @@ public final class TkAppAuth implements Take {
             new PsChain(
                 new PsByFlag(
                     new PsByFlag.Pair(
-                        PsLogout.class.getSimpleName(),
+                        Pattern.compile(
+                            Pattern.quote(PsLogout.class.getSimpleName())
+                        ),
                         new PsLogout()
                     ),
                     new PsByFlag.Pair(
-                        PsGithub.class.getSimpleName(),
+                        Pattern.compile(
+                            Pattern.quote(PsGithub.class.getSimpleName())
+                        ),
                         TkAppAuth.github()
                     )
                 ),
@@ -91,6 +97,7 @@ public final class TkAppAuth implements Take {
                 new CcXor(
                     new CcSalted(new CcPlain()),
                     Manifests.read("Stateful-SecurityKey")
+                        .getBytes(StandardCharsets.UTF_8)
                 )
             )
         );


### PR DESCRIPTION
@yegor256 — this PR pulls the project up to the latest stable releases of two of its build dependencies and contains the minimal production-code changes to keep `mvn clean install -Pqulice` passing on Linux/macOS/Windows + Java 21.

## Summary

* **`org.takes:takes`** `1.25.0` → `1.26.0`
* **`com.qulice:qulice-maven-plugin`** `0.25.1` → `0.25.2`

## Why takes 1.26.0 needed code changes

The 1.26.0 release tightened a few APIs that this codebase used:

* `org.takes.facets.auth.PsByFlag.Pair(...)` now takes a `java.util.regex.Pattern` instead of a `String` for its key. Wrapping the existing class-name strings with `Pattern.compile(Pattern.quote(...))` preserves the previous flag matching exactly.
* `org.takes.facets.auth.codecs.CcXor(...)` now takes a `byte[]` secret instead of a `String`. The `Stateful-SecurityKey` manifest value is now converted with `getBytes(StandardCharsets.UTF_8)`.

Both changes are confined to `co.stateful.web.TkAppAuth`.

## Why qulice 0.25.2 needed code changes

qulice 0.25.2 enables the PMD `PublicMemberInNonPublicType` rule, which flags package-private classes that expose `public` members. The three DynamoDB DAOs in `co.stateful.core` — `DefaultUser`, `DyCounters`, `DyLocks` — are all package-private, but their column-name constants were declared `public static final`. The `public` modifier is dropped so the visibility of those constants matches the visibility of the enclosing class; they are only used within the package anyway.

## Verification

* Local: `LANG=C.UTF-8 LC_ALL=C.UTF-8 mvn --batch-mode --errors clean install -Pqulice` → `BUILD SUCCESS` (Java 21 on Linux). All 18 surefire test classes pass.
* Sister linters were not exercised locally; please trigger CI when convenient — the workflow runs on the PR head are sitting in `action_required` waiting for maintainer approval (first-time contributor).

## Notes for reviewer

* I considered upgrading qulice further to `0.27.6` (the latest), but `0.26.0` adds the new `ConstructorsCodeFreeCheck` rule which fundamentally clashes with the takes-style wrapping pattern used heavily in this codebase (`new TkX(make(base))`, `this.take = TkX.wrap(origin)`, etc.). Adopting it would require a wide-scope refactor of `TkApp`, `TkAppAuth`, `TkAppFallback`, `RsPage`, `DefaultUser`, and friends — outside the scope of a routine dep bump. `0.25.2` is the latest version before that rule was introduced.
* Most other declared deps in `pom.xml` (`commons-lang3 3.20.0`, `lombok 1.18.46`, `jcabi-log 0.24.3`, `mockito-core 5.23.0`, `aspectjrt 1.9.25.1`, etc.) are already on their latest stable versions, so no further bumps were needed in this PR.

https://claude.ai/code/session_014of3vLVigKUk5cG86mPrxL