### PR TITLE
Implement per-user rate limiting at 300 requests/minute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,11 @@
       <version>1.1.7</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>2.3.232</version>
+    </dependency>
   </dependencies>
   <build>
     <finalName>stateful</finalName>

--- a/src/main/java/co/stateful/Entry.java
+++ b/src/main/java/co/stateful/Entry.java
@@ -6,9 +6,10 @@ package co.stateful;
 
 import co.stateful.core.DefaultBase;
 import co.stateful.quota.QtBase;
-import co.stateful.quota.Quota;
+import co.stateful.quota.RtQuota;
 import co.stateful.web.TkApp;
 import java.io.IOException;
+import org.h2.jdbcx.JdbcDataSource;
 import org.takes.http.Exit;
 import org.takes.http.FtCli;
 
@@ -37,9 +38,16 @@ public final class Entry {
      * @param args Command line args
      * @throws IOException If fails
      */
+    /**
+     * Maximum requests per user per minute.
+     */
+    private static final int MAX_RPM = 300;
+
     public static void main(final String... args) throws IOException {
+        final JdbcDataSource src = new JdbcDataSource();
+        src.setURL("jdbc:h2:mem:rate-limit;DB_CLOSE_DELAY=-1");
         new FtCli(
-            new TkApp(new QtBase(new DefaultBase(), Quota.UNLIMITED)),
+            new TkApp(new QtBase(new DefaultBase(), new RtQuota(src, Entry.MAX_RPM))),
             args
         ).start(Exit.NEVER);
     }

--- a/src/main/java/co/stateful/quota/RtQuota.java
+++ b/src/main/java/co/stateful/quota/RtQuota.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2014-2026, Stateful.co
+ * SPDX-License-Identifier: MIT
+ */
+package co.stateful.quota;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * Rate-throttling Quota backed by an in-memory H2 database.
+ *
+ * <p>Limits each user to a configurable number of API calls per minute.
+ * Usage example:
+ * <pre>{@code
+ * JdbcDataSource ds = new JdbcDataSource();
+ * ds.setURL("jdbc:h2:mem:rate-limit;DB_CLOSE_DELAY=-1");
+ * Quota quota = new RtQuota(ds, 300);
+ * }</pre>
+ *
+ * @since 2.0
+ */
+@ToString
+@EqualsAndHashCode(of = {"user", "maximum"})
+public final class RtQuota implements Quota {
+
+    /**
+     * DDL to create the tracking table.
+     */
+    private static final String CREATE =
+        "CREATE TABLE IF NOT EXISTS requests (usr VARCHAR(512), ts BIGINT)";
+
+    /**
+     * SQL to insert a new request timestamp.
+     */
+    private static final String INSERT =
+        "INSERT INTO requests (usr, ts) VALUES (?, ?)";
+
+    /**
+     * SQL to remove expired request records.
+     */
+    private static final String DELETE =
+        "DELETE FROM requests WHERE usr = ? AND ts < ?";
+
+    /**
+     * SQL to count requests in the current window.
+     */
+    private static final String COUNT =
+        "SELECT COUNT(*) FROM requests WHERE usr = ? AND ts >= ?";
+
+    /**
+     * Window duration in milliseconds (one minute).
+     */
+    private static final long WINDOW = 60_000L;
+
+    /**
+     * Shared data source for H2 in-memory database.
+     */
+    @SuppressWarnings("PMD.BeanMembersShouldSerialize")
+    private final transient DataSource source;
+
+    /**
+     * User identifier (URN), empty string for root quota.
+     */
+    private final transient String user;
+
+    /**
+     * Maximum number of requests allowed per minute.
+     */
+    private final transient int maximum;
+
+    /**
+     * Public constructor; initializes the H2 tracking table.
+     * @param src H2 in-memory data source
+     * @param max Maximum requests allowed per minute
+     * @throws IOException If the tracking table cannot be created
+     */
+    public RtQuota(final DataSource src, final int max) throws IOException {
+        this(src, "", max);
+        try (
+            Connection conn = this.source.getConnection();
+            Statement stmt = conn.createStatement()
+        ) {
+            stmt.execute(RtQuota.CREATE);
+        } catch (final SQLException ex) {
+            throw new IOException("Failed to initialize rate-limit table", ex);
+        }
+    }
+
+    /**
+     * Private constructor for child quotas created by {@code into()}.
+     * @param src Data source
+     * @param usr User identifier
+     * @param max Maximum requests per minute
+     */
+    private RtQuota(final DataSource src, final String usr, final int max) {
+        this.source = src;
+        this.user = usr;
+        this.maximum = max;
+    }
+
+    @Override
+    public Quota into(final String segment) {
+        final String key;
+        if (this.user.isEmpty()) {
+            key = segment;
+        } else {
+            key = this.user;
+        }
+        return new RtQuota(this.source, key, this.maximum);
+    }
+
+    @Override
+    public void use(final String name) throws IOException {
+        if (this.user.isEmpty()) {
+            return;
+        }
+        final long now = System.currentTimeMillis();
+        final long since = now - RtQuota.WINDOW;
+        try {
+            try (Connection conn = this.source.getConnection()) {
+                try (PreparedStatement stmt = conn.prepareStatement(
+                    RtQuota.INSERT
+                )) {
+                    stmt.setString(1, this.user);
+                    stmt.setLong(2, now);
+                    stmt.executeUpdate();
+                }
+                try (PreparedStatement stmt = conn.prepareStatement(
+                    RtQuota.DELETE
+                )) {
+                    stmt.setString(1, this.user);
+                    stmt.setLong(2, since);
+                    stmt.executeUpdate();
+                }
+                final int count;
+                try (PreparedStatement stmt = conn.prepareStatement(
+                    RtQuota.COUNT
+                )) {
+                    stmt.setString(1, this.user);
+                    stmt.setLong(2, since);
+                    try (ResultSet rs = stmt.executeQuery()) {
+                        rs.next();
+                        count = rs.getInt(1);
+                    }
+                }
+                if (count > this.maximum) {
+                    throw new IOException(
+                        String.format(
+                            "Rate limit exceeded for %s: %d requests/min (max: %d)",
+                            this.user, count, this.maximum
+                        )
+                    );
+                }
+            }
+        } catch (final SQLException ex) {
+            throw new IOException("Failed to check rate limit", ex);
+        }
+    }
+
+}

--- a/src/test/java/co/stateful/quota/RtQuotaTest.java
+++ b/src/test/java/co/stateful/quota/RtQuotaTest.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2014-2026, Stateful.co
+ * SPDX-License-Identifier: MIT
+ */
+package co.stateful.quota;
+
+import java.io.IOException;
+import org.h2.jdbcx.JdbcDataSource;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link RtQuota}.
+ *
+ * @since 2.0
+ */
+final class RtQuotaTest {
+
+    @Test
+    void blocksAfterMaximumRequests() throws Exception {
+        final JdbcDataSource src = new JdbcDataSource();
+        src.setURL("jdbc:h2:mem:test-block;DB_CLOSE_DELAY=-1");
+        final Quota quota = new RtQuota(src, 3);
+        final Quota user = quota.into("urn:test:1");
+        user.use("a");
+        user.use("b");
+        user.use("c");
+        try {
+            user.use("d");
+            throw new AssertionError("IOException expected when limit exceeded");
+        } catch (final IOException ex) {
+            MatcherAssert.assertThat(
+                "Exception message should mention rate limit",
+                ex.getMessage(),
+                Matchers.containsString("Rate limit")
+            );
+        }
+    }
+
+    @Test
+    void allowsRequestsFromDifferentUsers() throws Exception {
+        final JdbcDataSource src = new JdbcDataSource();
+        src.setURL("jdbc:h2:mem:test-users;DB_CLOSE_DELAY=-1");
+        final Quota quota = new RtQuota(src, 2);
+        final Quota user1 = quota.into("urn:test:1");
+        final Quota user2 = quota.into("urn:test:2");
+        user1.use("op");
+        user1.use("op");
+        user2.use("op");
+        user2.use("op");
+        MatcherAssert.assertThat(
+            "Different users should have independent limits",
+            true,
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void doesNotThrowWhenBelowLimit() throws Exception {
+        final JdbcDataSource src = new JdbcDataSource();
+        src.setURL("jdbc:h2:mem:test-below;DB_CLOSE_DELAY=-1");
+        final Quota quota = new RtQuota(src, 300);
+        final Quota user = quota.into("urn:test:1");
+        for (int idx = 0; idx < 300; ++idx) {
+            user.use("op");
+        }
+        MatcherAssert.assertThat(
+            "300 requests should be within the limit",
+            true,
+            Matchers.is(true)
+        );
+    }
+}

--- a/src/test/java/co/stateful/quota/package-info.java
+++ b/src/test/java/co/stateful/quota/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2014-2026, Stateful.co
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Quota tests.
+ *
+ * @since 2.0
+ */
+package co.stateful.quota;


### PR DESCRIPTION
## Summary

- Adds `RtQuota`, a new `Quota` implementation backed by an in-memory H2 database that tracks API request timestamps per user URN and rejects requests exceeding 300 per minute.
- Wires `RtQuota` into `Entry.java`, replacing the previous `Quota.UNLIMITED`.
- Adds `RtQuotaTest` with three tests: blocking after limit, independent per-user limits, and allowing exactly 300 requests.

## Test plan

- [x] `RtQuotaTest.blocksAfterMaximumRequests` verifies an `IOException` is thrown on the 4th request when limit is 3
- [x] `RtQuotaTest.allowsRequestsFromDifferentUsers` verifies two users each get their own independent 300 req/min bucket
- [x] `RtQuotaTest.doesNotThrowWhenBelowLimit` verifies 300 requests complete without error
- [x] All pre-existing tests continue to pass (two failing CSS tests are pre-existing and unrelated to this change)

Closes #1