### PR TITLE
Upgrade qulice to 0.27.6 and fix all violations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,7 +345,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.25.2</version>
+            <version>0.27.6</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/main/resources/webapp/.*</exclude>

--- a/src/main/java/co/stateful/Entry.java
+++ b/src/main/java/co/stateful/Entry.java
@@ -9,6 +9,9 @@ import co.stateful.quota.QtBase;
 import co.stateful.quota.RtQuota;
 import co.stateful.web.TkApp;
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import org.h2.jdbcx.JdbcDataSource;
 import org.takes.http.Exit;
 import org.takes.http.FtCli;
@@ -27,6 +30,11 @@ import org.takes.http.FtCli;
 public final class Entry {
 
     /**
+     * Maximum requests per user per minute.
+     */
+    private static final int MAX_RPM = 300;
+
+    /**
      * Ctor.
      */
     private Entry() {
@@ -38,14 +46,17 @@ public final class Entry {
      * @param args Command line args
      * @throws IOException If fails
      */
-    /**
-     * Maximum requests per user per minute.
-     */
-    private static final int MAX_RPM = 300;
-
     public static void main(final String... args) throws IOException {
         final JdbcDataSource src = new JdbcDataSource();
         src.setURL("jdbc:h2:mem:rate-limit;DB_CLOSE_DELAY=-1");
+        try (
+            Connection conn = src.getConnection();
+            Statement stmt = conn.createStatement()
+        ) {
+            stmt.execute(RtQuota.SCHEMA);
+        } catch (final SQLException ex) {
+            throw new IOException("Failed to initialize rate-limit table", ex);
+        }
         new FtCli(
             new TkApp(new QtBase(new DefaultBase(), new RtQuota(src, Entry.MAX_RPM))),
             args

--- a/src/main/java/co/stateful/core/DefaultUser.java
+++ b/src/main/java/co/stateful/core/DefaultUser.java
@@ -33,7 +33,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 
 /**
  * Default user.
- *
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
@@ -59,46 +58,27 @@ final class DefaultUser implements User {
     static final String ATTR_TOKEN = "token";
 
     /**
+     * Shared DynamoDB region for all users; built once from the manifest.
+     */
+    private static final Region REGION = DefaultUser.region();
+
+    /**
      * Name of the user.
      */
     private final transient URN name;
 
     /**
-     * Region.
-     */
-    private final transient Region region;
-
-    /**
      * Ctor.
      * @param urn Name of it
      */
-    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     DefaultUser(final URN urn) {
         this.name = urn;
-        final String key = Manifests.read("Stateful-DynamoKey");
-        Credentials creds = new Credentials.Simple(
-            key,
-            Manifests.read("Stateful-DynamoSecret")
-        );
-        if ("AAAAABBBBBAAAAABBBBB".equals(key)) {
-            creds = new Credentials.Direct(
-                Credentials.Simple.class.cast(creds),
-                Integer.parseInt(
-                    Manifests.read("Stateful-DynamoPort")
-                )
-            );
-        }
-        Logger.info(DefaultUser.class, "Connecting to AWS as %s...", key);
-        this.region = new Region.Prefixed(
-            new Region.Simple(creds),
-            Manifests.read("Stateful-DynamoPrefix")
-        );
     }
 
     @Override
     @Cacheable(forever = true)
     public boolean exists() {
-        return this.region.table(DefaultUser.TOKENS)
+        return DefaultUser.REGION.table(DefaultUser.TOKENS)
             .frame().through(new QueryValve())
             .where(DefaultUser.HASH, Conditions.equalTo(this.name))
             .iterator().hasNext();
@@ -107,7 +87,7 @@ final class DefaultUser implements User {
     @Override
     @Cacheable(lifetime = 1, unit = TimeUnit.HOURS)
     public String token() throws IOException {
-        final Iterator<Item> items = this.region.table(DefaultUser.TOKENS)
+        final Iterator<Item> items = DefaultUser.REGION.table(DefaultUser.TOKENS)
             .frame().through(new QueryValve())
             .where(DefaultUser.HASH, Conditions.equalTo(this.name))
             .iterator();
@@ -124,33 +104,54 @@ final class DefaultUser implements User {
     @Override
     @Cacheable.FlushAfter
     public void refresh() throws IOException {
-        this.region.table(DefaultUser.TOKENS).put(
-            new Attributes()
-                .with(DefaultUser.HASH, this.name)
-                .with(
-                    DefaultUser.ATTR_TOKEN,
-                    Joiner.on('-').join(
-                        Iterables.limit(
-                            Splitter.fixedLength(4).split(
-                                DigestUtils.md5Hex(
-                                    RandomStringUtils.secure().next(10)
-                                ).toUpperCase(Locale.ENGLISH)
-                            ),
-                            4
-                        )
+        DefaultUser.REGION.table(DefaultUser.TOKENS).put(
+            new Attributes().with(DefaultUser.HASH, this.name).with(
+                DefaultUser.ATTR_TOKEN,
+                Joiner.on('-').join(
+                    Iterables.limit(
+                        Splitter.fixedLength(4).split(
+                            DigestUtils.md5Hex(
+                                RandomStringUtils.secure().next(10)
+                            ).toUpperCase(Locale.ENGLISH)
+                        ),
+                        4
                     )
                 )
+            )
         );
     }
 
     @Override
     @Cacheable(lifetime = 1, unit = TimeUnit.HOURS)
     public Counters counters() {
-        return new DyCounters(this.region.table(DyCounters.TBL), this.name);
+        return new DyCounters(DefaultUser.REGION.table(DyCounters.TBL), this.name);
     }
 
     @Override
     public Locks locks() {
-        return new DyLocks(this.region.table(DyLocks.TBL), this.name);
+        return new DyLocks(DefaultUser.REGION.table(DyLocks.TBL), this.name);
+    }
+
+    /**
+     * Build the shared DynamoDB region from the manifest.
+     * @return Prefixed region
+     */
+    private static Region region() {
+        final String key = Manifests.read("Stateful-DynamoKey");
+        Credentials creds = new Credentials.Simple(
+            key,
+            Manifests.read("Stateful-DynamoSecret")
+        );
+        if ("AAAAABBBBBAAAAABBBBB".equals(key)) {
+            creds = new Credentials.Direct(
+                Credentials.Simple.class.cast(creds),
+                Integer.parseInt(Manifests.read("Stateful-DynamoPort"))
+            );
+        }
+        Logger.info(DefaultUser.class, "Connecting to AWS as %s...", key);
+        return new Region.Prefixed(
+            new Region.Simple(creds),
+            Manifests.read("Stateful-DynamoPrefix")
+        );
     }
 }

--- a/src/main/java/co/stateful/core/DyCounter.java
+++ b/src/main/java/co/stateful/core/DyCounter.java
@@ -18,7 +18,6 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValueUpdate;
 
 /**
  * Counter in DynamoDB.
- *
  * @since 0.1
  */
 @Immutable

--- a/src/main/java/co/stateful/core/DyCounters.java
+++ b/src/main/java/co/stateful/core/DyCounters.java
@@ -25,7 +25,6 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * Counters in DynamoDB.
- *
  * @since 0.1
  */
 @Immutable

--- a/src/main/java/co/stateful/core/DyLocks.java
+++ b/src/main/java/co/stateful/core/DyLocks.java
@@ -27,7 +27,6 @@ import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 
 /**
  * Locks in DynamoDB.
- *
  * @since 1.1
  */
 @Immutable
@@ -101,29 +100,20 @@ final class DyLocks implements Locks {
         String msg = "";
         try {
             this.table.region().aws().putItem(
-                PutItemRequest.builder()
-                    .tableName(this.table.name())
-                    .item(
-                        new ImmutableMap.Builder<String, AttributeValue>()
-                            .put(
-                                DyLocks.HASH,
-                                AttributeValue.builder().s(this.owner.toString()).build()
-                            )
-                            .put(
-                                DyLocks.RANGE,
-                                AttributeValue.builder().s(name).build()
-                            )
-                            .put(
-                                DyLocks.ATTR_LABEL,
-                                AttributeValue.builder().s(label).build()
-                            )
-                            .build()
-                    )
-                    .conditionExpression("attribute_not_exists(#lbl)")
-                    .expressionAttributeNames(
-                        ImmutableMap.of("#lbl", DyLocks.ATTR_LABEL)
-                    )
-                    .build()
+                PutItemRequest.builder().tableName(this.table.name()).item(
+                    new ImmutableMap.Builder<String, AttributeValue>().put(
+                        DyLocks.HASH,
+                        AttributeValue.builder().s(this.owner.toString()).build()
+                    ).put(
+                        DyLocks.RANGE,
+                        AttributeValue.builder().s(name).build()
+                    ).put(
+                        DyLocks.ATTR_LABEL,
+                        AttributeValue.builder().s(label).build()
+                    ).build()
+                ).conditionExpression("attribute_not_exists(#lbl)").expressionAttributeNames(
+                    ImmutableMap.of("#lbl", DyLocks.ATTR_LABEL)
+                ).build()
             );
         } catch (final ConditionalCheckFailedException ex) {
             msg = ex.getMessage();

--- a/src/main/java/co/stateful/core/package-info.java
+++ b/src/main/java/co/stateful/core/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Core.
- *
  * @since 0.1
  */
 package co.stateful.core;

--- a/src/main/java/co/stateful/package-info.java
+++ b/src/main/java/co/stateful/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Main.
- *
  * @since 1.6.6
  */
 package co.stateful;

--- a/src/main/java/co/stateful/quota/QtBase.java
+++ b/src/main/java/co/stateful/quota/QtBase.java
@@ -14,7 +14,6 @@ import lombok.ToString;
 
 /**
  * Quota on a Base.
- *
  * @since 1.4
  */
 @Immutable

--- a/src/main/java/co/stateful/quota/QtCounter.java
+++ b/src/main/java/co/stateful/quota/QtCounter.java
@@ -14,7 +14,6 @@ import lombok.ToString;
 
 /**
  * Quota on counter.
- *
  * @since 1.4
  */
 @Immutable

--- a/src/main/java/co/stateful/quota/QtCounters.java
+++ b/src/main/java/co/stateful/quota/QtCounters.java
@@ -14,7 +14,6 @@ import lombok.ToString;
 
 /**
  * Quota on counters.
- *
  * @since 1.4
  */
 @Immutable

--- a/src/main/java/co/stateful/quota/QtLocks.java
+++ b/src/main/java/co/stateful/quota/QtLocks.java
@@ -14,7 +14,6 @@ import lombok.ToString;
 
 /**
  * Quota on Locks.
- *
  * @since 1.4
  */
 @Immutable

--- a/src/main/java/co/stateful/quota/QtUser.java
+++ b/src/main/java/co/stateful/quota/QtUser.java
@@ -15,7 +15,6 @@ import lombok.ToString;
 
 /**
  * Quota on a User.
- *
  * @since 1.4
  */
 @Immutable

--- a/src/main/java/co/stateful/quota/Quota.java
+++ b/src/main/java/co/stateful/quota/Quota.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 
 /**
  * Quota.
- *
  * @since 1.4
  */
 @Immutable
@@ -43,5 +42,4 @@ public interface Quota {
      * @throws IOException If fails due to IO problem
      */
     void use(String name) throws IOException;
-
 }

--- a/src/main/java/co/stateful/quota/RtQuota.java
+++ b/src/main/java/co/stateful/quota/RtQuota.java
@@ -9,7 +9,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import javax.sql.DataSource;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -32,9 +31,12 @@ import lombok.ToString;
 public final class RtQuota implements Quota {
 
     /**
-     * DDL to create the tracking table.
+     * DDL that ensures the rate-limit tracking table exists.
+     *
+     * <p>Run this once on the configured data source before constructing any
+     * {@link RtQuota}; the constructor does not create the schema itself.
      */
-    private static final String CREATE =
+    public static final String SCHEMA =
         "CREATE TABLE IF NOT EXISTS requests (usr VARCHAR(512), ts BIGINT)";
 
     /**
@@ -63,7 +65,6 @@ public final class RtQuota implements Quota {
     /**
      * Shared data source for H2 in-memory database.
      */
-    @SuppressWarnings("PMD.BeanMembersShouldSerialize")
     private final transient DataSource source;
 
     /**
@@ -77,21 +78,12 @@ public final class RtQuota implements Quota {
     private final transient int maximum;
 
     /**
-     * Public constructor; initializes the H2 tracking table.
+     * Public constructor.
      * @param src H2 in-memory data source
      * @param max Maximum requests allowed per minute
-     * @throws IOException If the tracking table cannot be created
      */
-    public RtQuota(final DataSource src, final int max) throws IOException {
+    public RtQuota(final DataSource src, final int max) {
         this(src, "", max);
-        try (
-            Connection conn = this.source.getConnection();
-            Statement stmt = conn.createStatement()
-        ) {
-            stmt.execute(RtQuota.CREATE);
-        } catch (final SQLException ex) {
-            throw new IOException("Failed to initialize rate-limit table", ex);
-        }
     }
 
     /**
@@ -124,45 +116,71 @@ public final class RtQuota implements Quota {
         }
         final long now = System.currentTimeMillis();
         final long since = now - RtQuota.WINDOW;
-        try {
-            try (Connection conn = this.source.getConnection()) {
-                try (PreparedStatement stmt = conn.prepareStatement(
-                    RtQuota.INSERT
-                )) {
-                    stmt.setString(1, this.user);
-                    stmt.setLong(2, now);
-                    stmt.executeUpdate();
-                }
-                try (PreparedStatement stmt = conn.prepareStatement(
-                    RtQuota.DELETE
-                )) {
-                    stmt.setString(1, this.user);
-                    stmt.setLong(2, since);
-                    stmt.executeUpdate();
-                }
-                final int count;
-                try (PreparedStatement stmt = conn.prepareStatement(
-                    RtQuota.COUNT
-                )) {
-                    stmt.setString(1, this.user);
-                    stmt.setLong(2, since);
-                    try (ResultSet rs = stmt.executeQuery()) {
-                        rs.next();
-                        count = rs.getInt(1);
-                    }
-                }
-                if (count > this.maximum) {
-                    throw new IOException(
-                        String.format(
-                            "Rate limit exceeded for %s: %d requests/min (max: %d)",
-                            this.user, count, this.maximum
-                        )
-                    );
-                }
+        try (Connection conn = this.source.getConnection()) {
+            this.insert(conn, now);
+            this.purge(conn, since);
+            final int count = this.count(conn, since);
+            if (count > this.maximum) {
+                throw new IOException(
+                    String.format(
+                        "Rate limit exceeded for %s: %d requests/min (max: %d)",
+                        this.user, count, this.maximum
+                    )
+                );
             }
         } catch (final SQLException ex) {
             throw new IOException("Failed to check rate limit", ex);
         }
     }
 
+    /**
+     * Insert a request timestamp for the current user.
+     * @param conn Database connection
+     * @param when Timestamp of the request
+     * @throws SQLException If a database error occurs
+     */
+    private void insert(final Connection conn, final long when)
+        throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(RtQuota.INSERT)) {
+            stmt.setString(1, this.user);
+            stmt.setLong(2, when);
+            stmt.executeUpdate();
+        }
+    }
+
+    /**
+     * Remove expired request records for the current user.
+     * @param conn Database connection
+     * @param since Cutoff timestamp; entries older than this are removed
+     * @throws SQLException If a database error occurs
+     */
+    private void purge(final Connection conn, final long since)
+        throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(RtQuota.DELETE)) {
+            stmt.setString(1, this.user);
+            stmt.setLong(2, since);
+            stmt.executeUpdate();
+        }
+    }
+
+    /**
+     * Count the requests by the current user in the active window.
+     * @param conn Database connection
+     * @param since Window start timestamp
+     * @return Number of requests within the window
+     * @throws SQLException If a database error occurs
+     */
+    private int count(final Connection conn, final long since)
+        throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(RtQuota.COUNT)) {
+            stmt.setString(1, this.user);
+            stmt.setLong(2, since);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (!rs.next()) {
+                    throw new SQLException("Empty count result");
+                }
+                return rs.getInt(1);
+            }
+        }
+    }
 }

--- a/src/main/java/co/stateful/quota/package-info.java
+++ b/src/main/java/co/stateful/quota/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Quota.
- *
  * @since 1.4
  */
 package co.stateful.quota;

--- a/src/main/java/co/stateful/spi/Base.java
+++ b/src/main/java/co/stateful/spi/Base.java
@@ -9,7 +9,6 @@ import com.jcabi.urn.URN;
 
 /**
  * Base.
- *
  * @since 0.1
  */
 @Immutable
@@ -22,5 +21,4 @@ public interface Base {
      * @return User
      */
     User user(URN urn);
-
 }

--- a/src/main/java/co/stateful/spi/Counter.java
+++ b/src/main/java/co/stateful/spi/Counter.java
@@ -10,7 +10,6 @@ import java.math.BigDecimal;
 
 /**
  * Counter.
- *
  * @since 0.1
  */
 @Immutable
@@ -30,5 +29,4 @@ public interface Counter {
      * @throws IOException If fails due to IO problem
      */
     BigDecimal increment(BigDecimal delta) throws IOException;
-
 }

--- a/src/main/java/co/stateful/spi/Counters.java
+++ b/src/main/java/co/stateful/spi/Counters.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 
 /**
  * Counters.
- *
  * @since 0.1
  */
 @Immutable
@@ -47,5 +46,4 @@ public interface Counters {
      * @return Counter
      */
     Counter get(String name);
-
 }

--- a/src/main/java/co/stateful/spi/Locks.java
+++ b/src/main/java/co/stateful/spi/Locks.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 /**
  * Locks.
- *
  * @since 1.1
  */
 @Immutable
@@ -61,5 +60,4 @@ public interface Locks {
      * @since 1.6
      */
     String unlock(String name, String label) throws IOException;
-
 }

--- a/src/main/java/co/stateful/spi/User.java
+++ b/src/main/java/co/stateful/spi/User.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 
 /**
  * User.
- *
  * @since 0.1
  */
 @Immutable
@@ -46,5 +45,4 @@ public interface User {
      * @since 1.1
      */
     Locks locks();
-
 }

--- a/src/main/java/co/stateful/spi/package-info.java
+++ b/src/main/java/co/stateful/spi/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * SPI.
- *
  * @since 1.4
  */
 package co.stateful.spi;

--- a/src/main/java/co/stateful/web/RqUser.java
+++ b/src/main/java/co/stateful/web/RqUser.java
@@ -46,8 +46,7 @@ public final class RqUser extends RqWrap {
     /**
      * Get user.
      * @return User
-     * @throws IOException If fails
-     * @throws HttpException If not authenticated
+     * @throws IOException If fails or not authenticated
      */
     public User user() throws IOException {
         final Identity identity = new RqAuth(this).identity();

--- a/src/main/java/co/stateful/web/RsPage.java
+++ b/src/main/java/co/stateful/web/RsPage.java
@@ -6,6 +6,7 @@ package co.stateful.web;
 
 import com.jcabi.manifests.Manifests;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.HashSet;
 import lombok.EqualsAndHashCode;
@@ -49,79 +50,111 @@ import org.takes.rs.xe.XeStylesheet;
 public final class RsPage extends RsWrap {
 
     /**
+     * Pre-loaded GitHub app id from the manifest.
+     */
+    private static final String GITHUB_ID =
+        Manifests.read("Stateful-GithubId");
+
+    /**
+     * Pre-loaded version string in {@code version/revision} format.
+     */
+    private static final String VERSION = String.format(
+        "%s/%s",
+        Manifests.read("Stateful-Version"),
+        Manifests.read("Stateful-Revision")
+    );
+
+    /**
      * Ctor.
      * @param xsl XSL stylesheet path
      * @param req Request
      * @param sources Extra sources
-     * @throws IOException If fails
      */
     public RsPage(final String xsl, final Request req,
-        final XeSource... sources) throws IOException {
-        super(RsPage.make(xsl, req, sources));
+        final XeSource... sources) {
+        super(new RsPage.Negotiated(xsl, req, sources));
     }
 
     /**
-     * Build response with content negotiation.
-     * @param xsl XSL stylesheet path
-     * @param req Request
-     * @param sources Extra sources
-     * @return Response
-     * @throws IOException If fails
+     * Response wrapper that picks the content type based on the request's
+     * Accept header and lazily delegates to either raw XML or XSL-transformed
+     * HTML.
+     * @since 2.0
      */
-    private static Response make(final String xsl, final Request req,
-        final XeSource... sources) throws IOException {
-        return RsPage.negotiate(
-            new RsXembly(
-                new XeStylesheet(xsl),
+    private static final class Negotiated implements Response {
+
+        /**
+         * XSL stylesheet path applied when the client wants HTML.
+         */
+        private final String xsl;
+
+        /**
+         * Original request, used for content negotiation.
+         */
+        private final Request req;
+
+        /**
+         * Extra XE sources merged into the page.
+         */
+        private final XeSource[] sources;
+
+        /**
+         * Ctor.
+         * @param sheet XSL stylesheet path
+         * @param request Original HTTP request
+         * @param srcs Extra XE sources to merge into the page
+         */
+        Negotiated(final String sheet, final Request request,
+            final XeSource... srcs) {
+            this.xsl = sheet;
+            this.req = request;
+            this.sources = srcs.clone();
+        }
+
+        @Override
+        public Iterable<String> head() throws IOException {
+            return this.choose().head();
+        }
+
+        @Override
+        public InputStream body() throws IOException {
+            return this.choose().body();
+        }
+
+        /**
+         * Compose the response, applying content negotiation.
+         * @return Either the raw XML response or its HTML transform
+         * @throws IOException If header inspection fails
+         */
+        private Response choose() throws IOException {
+            final Response raw = new RsXembly(
+                new XeStylesheet(this.xsl),
                 new XeAppend(
                     "page",
-                    new XeChain(sources),
+                    new XeChain(this.sources),
                     new XeMillis(),
                     new XeSla(),
                     new XeDate(),
                     new XeLocalhost(),
                     new XeLink("home", "/"),
-                    new XeGithubLink(req, Manifests.read("Stateful-GithubId")),
+                    new XeGithubLink(this.req, RsPage.GITHUB_ID),
                     new XeAppend(
                         "version",
-                        new XeAppend("name", RsPage.version())
+                        new XeAppend("name", RsPage.VERSION)
                     )
                 )
-            ),
-            req
-        );
-    }
-
-    /**
-     * Content negotiation based on Accept header.
-     * @param raw Raw XML response
-     * @param req Request
-     * @return Response with correct content type
-     * @throws IOException If fails
-     */
-    private static Response negotiate(final Response raw, final Request req)
-        throws IOException {
-        final Response result;
-        final Collection<String> headers = new HashSet<>(
-            new RqHeaders.Base(req).header("Accept")
-        );
-        if (headers.contains("application/xml") || headers.contains("text/xml")) {
-            result = new RsWithType(raw, "text/xml");
-        } else {
-            result = new RsXslt(new RsWithType(raw, "text/html"));
+            );
+            final Collection<String> headers = new HashSet<>(
+                new RqHeaders.Base(this.req).header("Accept")
+            );
+            final Response result;
+            if (headers.contains("application/xml")
+                || headers.contains("text/xml")) {
+                result = new RsWithType(raw, "text/xml");
+            } else {
+                result = new RsXslt(new RsWithType(raw, "text/html"));
+            }
+            return result;
         }
-        return result;
-    }
-
-    /**
-     * Read version from manifest.
-     * @return Version string
-     */
-    private static String version() {
-        return String.format(
-            "%s/%s",
-            Manifests.read("Stateful-Version"),
-            Manifests.read("Stateful-Revision")
-        );
     }
 }

--- a/src/main/java/co/stateful/web/TkApp.java
+++ b/src/main/java/co/stateful/web/TkApp.java
@@ -7,6 +7,8 @@ package co.stateful.web;
 import co.stateful.spi.Base;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.takes.Request;
+import org.takes.Response;
 import org.takes.Take;
 import org.takes.facets.flash.TkFlash;
 import org.takes.facets.fork.FkMethods;
@@ -49,21 +51,101 @@ public final class TkApp extends TkWrap {
      * @param base Base
      */
     public TkApp(final Base base) {
-        super(TkApp.make(base));
-    }
-
-    /**
-     * Create main take.
-     * @param base Base
-     * @return Take
-     */
-    private static Take make(final Base base) {
-        return new TkAppFallback(
-            new TkAppAuth(
-                base,
-                new TkForward(
-                    new TkFlash(
-                        TkApp.routes(base)
+        super(
+            new TkAppFallback(
+                new TkAppAuth(
+                    base,
+                    new TkForward(
+                        new TkFlash(
+                            new TkFork(
+                                new FkRegex(
+                                    "/robots.txt",
+                                    new TkStatic(TkApp.ROBOTS)
+                                ),
+                                new FkRegex(
+                                    "/css/.*",
+                                    new TkWithType(
+                                        new TkStatic(TkApp.WEBAPP, true),
+                                        "text/css"
+                                    )
+                                ),
+                                new FkRegex(
+                                    "/js/.*",
+                                    new TkStatic(TkApp.WEBAPP, true)
+                                ),
+                                new FkRegex(
+                                    "/images/.*\\.svg",
+                                    new TkWithType(
+                                        new TkStatic(TkApp.WEBAPP, true),
+                                        "image/svg+xml"
+                                    )
+                                ),
+                                new FkRegex(
+                                    "/images/.*",
+                                    new TkStatic(TkApp.WEBAPP, true)
+                                ),
+                                new FkRegex(
+                                    "/xsl/.*",
+                                    new TkWithType(
+                                        new TkStatic(TkApp.WEBAPP, true),
+                                        "text/xsl"
+                                    )
+                                ),
+                                new FkRegex("/", new TkHome(base)),
+                                new FkRegex("/error", new TkError(base)),
+                                new FkRegex("/counters", new TkCounters(base)),
+                                new FkRegex(
+                                    "/counters/add",
+                                    new TkFork(
+                                        new FkMethods(
+                                            "POST",
+                                            new TkCounterAdd(base)
+                                        )
+                                    )
+                                ),
+                                new FkRegex(
+                                    "/counters/delete",
+                                    new TkCounterDelete(base)
+                                ),
+                                new FkRegex(
+                                    "/c/(?<name>[^/]+)/set",
+                                    new TkFork(
+                                        new FkMethods(
+                                            "PUT",
+                                            (Take) req -> TkApp.counter(
+                                                base, req, true
+                                            )
+                                        ),
+                                        new FkMethods(
+                                            "GET",
+                                            (Take) req -> TkApp.counter(
+                                                base, req, true
+                                            )
+                                        )
+                                    )
+                                ),
+                                new FkRegex(
+                                    "/c/(?<name>[^/]+)/inc",
+                                    (Take) req -> TkApp.counter(base, req, false)
+                                ),
+                                new FkRegex("/k", new TkLocks(base)),
+                                new FkRegex(
+                                    "/k/lock",
+                                    new TkFork(
+                                        new FkMethods(
+                                            "POST",
+                                            new TkLockCreate(base)
+                                        )
+                                    )
+                                ),
+                                new FkRegex("/k/unlock", new TkUnlock(base)),
+                                new FkRegex("/k/label", new TkLockLabel(base)),
+                                new FkRegex(
+                                    "/u/refresh",
+                                    new TkUserRefresh(base)
+                                )
+                            )
+                        )
                     )
                 )
             )
@@ -71,89 +153,31 @@ public final class TkApp extends TkWrap {
     }
 
     /**
-     * Create routes.
+     * Dispatch a counter-set or counter-increment request.
+     *
+     * <p>Extracts the counter name from the URL, then delegates to the
+     * appropriate take.
+     *
      * @param base Base
-     * @return Take
+     * @param req Incoming request
+     * @param set True for set, false for increment
+     * @return Response from the dispatched take
+     * @throws Exception If the take fails
      */
-    private static Take routes(final Base base) {
-        return new TkFork(
-            new FkRegex("/robots.txt", new TkStatic(TkApp.ROBOTS)),
-            new FkRegex(
-                "/css/.*",
-                new TkWithType(new TkStatic(TkApp.WEBAPP, true), "text/css")
-            ),
-            new FkRegex("/js/.*", new TkStatic(TkApp.WEBAPP, true)),
-            new FkRegex(
-                "/images/.*\\.svg",
-                new TkWithType(new TkStatic(TkApp.WEBAPP, true), "image/svg+xml")
-            ),
-            new FkRegex("/images/.*", new TkStatic(TkApp.WEBAPP, true)),
-            new FkRegex(
-                "/xsl/.*",
-                new TkWithType(new TkStatic(TkApp.WEBAPP, true), "text/xsl")
-            ),
-            new FkRegex("/", new TkHome(base)),
-            new FkRegex("/error", new TkError(base)),
-            new FkRegex("/counters", new TkCounters(base)),
-            new FkRegex(
-                "/counters/add",
-                new TkFork(
-                    new FkMethods("POST", new TkCounterAdd(base))
-                )
-            ),
-            new FkRegex("/counters/delete", new TkCounterDelete(base)),
-            new FkRegex(
-                "/c/(?<name>[^/]+)/set",
-                new TkFork(
-                    new FkMethods("PUT", TkApp.counterSet(base)),
-                    new FkMethods("GET", TkApp.counterSet(base))
-                )
-            ),
-            new FkRegex("/c/(?<name>[^/]+)/inc", TkApp.counterInc(base)),
-            new FkRegex("/k", new TkLocks(base)),
-            new FkRegex(
-                "/k/lock",
-                new TkFork(
-                    new FkMethods("POST", new TkLockCreate(base))
-                )
-            ),
-            new FkRegex("/k/unlock", new TkUnlock(base)),
-            new FkRegex("/k/label", new TkLockLabel(base)),
-            new FkRegex("/u/refresh", new TkUserRefresh(base))
+    private static Response counter(final Base base, final Request req,
+        final boolean set) throws Exception {
+        final Matcher matcher = TkApp.PTN_COUNTER.matcher(
+            req.head().iterator().next().split(" ")[1]
         );
-    }
-
-    /**
-     * Counter set take.
-     * @param base Base
-     * @return Take
-     */
-    private static Take counterSet(final Base base) {
-        return req -> {
-            final Matcher matcher = TkApp.PTN_COUNTER.matcher(
-                req.head().iterator().next().split(" ")[1]
-            );
-            if (!matcher.matches()) {
-                throw new IllegalStateException("Invalid counter URL");
-            }
-            return new TkCounterSet(base, matcher.group(1)).act(req);
-        };
-    }
-
-    /**
-     * Counter increment take.
-     * @param base Base
-     * @return Take
-     */
-    private static Take counterInc(final Base base) {
-        return req -> {
-            final Matcher matcher = TkApp.PTN_COUNTER.matcher(
-                req.head().iterator().next().split(" ")[1]
-            );
-            if (!matcher.matches()) {
-                throw new IllegalStateException("Invalid counter URL");
-            }
-            return new TkCounterInc(base, matcher.group(1)).act(req);
-        };
+        if (!matcher.matches()) {
+            throw new IllegalStateException("Invalid counter URL");
+        }
+        final Take take;
+        if (set) {
+            take = new TkCounterSet(base, matcher.group(1));
+        } else {
+            take = new TkCounterInc(base, matcher.group(1));
+        }
+        return take.act(req);
     }
 }

--- a/src/main/java/co/stateful/web/TkAppAuth.java
+++ b/src/main/java/co/stateful/web/TkAppAuth.java
@@ -38,6 +38,47 @@ import org.takes.facets.auth.social.PsGithub;
 public final class TkAppAuth implements Take {
 
     /**
+     * Pattern matching the PsLogout flag value.
+     */
+    private static final Pattern PTN_LOGOUT =
+        Pattern.compile(Pattern.quote(PsLogout.class.getSimpleName()));
+
+    /**
+     * Pattern matching the PsGithub flag value.
+     */
+    private static final Pattern PTN_GITHUB =
+        Pattern.compile(Pattern.quote(PsGithub.class.getSimpleName()));
+
+    /**
+     * Shared cookie codec, derived from the manifest security key.
+     */
+    private static final CcSafe COOKIE_CODEC = new CcSafe(
+        new CcHex(
+            new CcXor(
+                new CcSalted(new CcPlain()),
+                Manifests.read("Stateful-SecurityKey")
+                    .getBytes(StandardCharsets.UTF_8)
+            )
+        )
+    );
+
+    /**
+     * Github OAuth provider.
+     */
+    private static final PsGithub GITHUB = new PsGithub(
+        Manifests.read("Stateful-GithubId"),
+        Manifests.read("Stateful-GithubSecret")
+    );
+
+    /**
+     * Test authentication provider, enabled only in CI dev builds.
+     */
+    private static final PsFake TESTER = new PsFake(
+        "1234567".equals(Manifests.read("Stateful-Revision"))
+            && !"-".equals(Manifests.read("Stateful-DynamoKey"))
+    );
+
+    /**
      * Origin take.
      */
     private final Take take;
@@ -48,80 +89,22 @@ public final class TkAppAuth implements Take {
      * @param origin Origin take
      */
     public TkAppAuth(final Base base, final Take origin) {
-        this.take = TkAppAuth.auth(base, origin);
+        this.take = new TkAuth(
+            origin,
+            new PsChain(
+                new PsByFlag(
+                    new PsByFlag.Pair(TkAppAuth.PTN_LOGOUT, new PsLogout()),
+                    new PsByFlag.Pair(TkAppAuth.PTN_GITHUB, TkAppAuth.GITHUB)
+                ),
+                new PsHeader(base),
+                new PsCookie(TkAppAuth.COOKIE_CODEC),
+                TkAppAuth.TESTER
+            )
+        );
     }
 
     @Override
     public Response act(final Request req) throws Exception {
         return this.take.act(req);
-    }
-
-    /**
-     * Create authenticated take.
-     * @param base Base
-     * @param origin Origin take
-     * @return Authenticated take
-     */
-    private static Take auth(final Base base, final Take origin) {
-        return new TkAuth(
-            origin,
-            new PsChain(
-                new PsByFlag(
-                    new PsByFlag.Pair(
-                        Pattern.compile(
-                            Pattern.quote(PsLogout.class.getSimpleName())
-                        ),
-                        new PsLogout()
-                    ),
-                    new PsByFlag.Pair(
-                        Pattern.compile(
-                            Pattern.quote(PsGithub.class.getSimpleName())
-                        ),
-                        TkAppAuth.github()
-                    )
-                ),
-                new PsHeader(base),
-                new PsCookie(TkAppAuth.codec()),
-                TkAppAuth.tester()
-            )
-        );
-    }
-
-    /**
-     * Cookie codec.
-     * @return Codec
-     */
-    private static CcSafe codec() {
-        return new CcSafe(
-            new CcHex(
-                new CcXor(
-                    new CcSalted(new CcPlain()),
-                    Manifests.read("Stateful-SecurityKey")
-                        .getBytes(StandardCharsets.UTF_8)
-                )
-            )
-        );
-    }
-
-    /**
-     * Github provider.
-     * @return Pass
-     */
-    private static PsGithub github() {
-        return new PsGithub(
-            Manifests.read("Stateful-GithubId"),
-            Manifests.read("Stateful-GithubSecret")
-        );
-    }
-
-    /**
-     * Test authentication provider.
-     * @return Pass
-     */
-    private static PsFake tester() {
-        return new PsFake(
-            "1234567".equals(Manifests.read("Stateful-Revision"))
-                && !"-".equals(Manifests.read("Stateful-DynamoKey"))
-        );
     }
 }

--- a/src/main/java/co/stateful/web/TkAppFallback.java
+++ b/src/main/java/co/stateful/web/TkAppFallback.java
@@ -41,21 +41,7 @@ public final class TkAppFallback implements Take {
      * @param origin Origin take
      */
     public TkAppFallback(final Take origin) {
-        this.take = TkAppFallback.wrap(origin);
-    }
-
-    @Override
-    public Response act(final Request req) throws Exception {
-        return this.take.act(req);
-    }
-
-    /**
-     * Wrap with fallback.
-     * @param origin Origin take
-     * @return Wrapped take
-     */
-    private static Take wrap(final Take origin) {
-        return new TkFallback(
+        this.take = new TkFallback(
             origin,
             new FbChain(
                 new FbStatus(
@@ -80,6 +66,11 @@ public final class TkAppFallback implements Take {
                 }
             )
         );
+    }
+
+    @Override
+    public Response act(final Request req) throws Exception {
+        return this.take.act(req);
     }
 
     /**

--- a/src/main/java/co/stateful/web/TkAuthenticated.java
+++ b/src/main/java/co/stateful/web/TkAuthenticated.java
@@ -54,33 +54,41 @@ public final class TkAuthenticated {
         final Identity identity = new RqAuth(req).identity();
         return new XeWhen(
             !identity.equals(Identity.ANONYMOUS),
-            () -> new XeChain(
-                new XeDirectives(
-                    new Directives()
-                        .add("identity")
-                        .add("urn").set(identity.urn()).up()
-                        .add("name").set(
-                            identity.properties().getOrDefault("name", "unknown")
-                        ).up()
-                        .add("photo").set(
-                            identity.properties().getOrDefault(
-                                "picture",
-                                "/images/pomegranate.svg"
-                            )
-                        ).up()
-                        .up()
-                ),
-                new XeAppend(
-                    "token",
-                    this.base.user(
-                        URN.create(identity.urn())
-                    ).token()
-                ),
-                new XeLink("menu:home", "/"),
-                new XeLink("menu:counters", "/counters"),
-                new XeLink("menu:locks", "/k"),
-                new XeLink("user:refresh", "/u/refresh")
-            )
+            () -> this.chain(identity)
+        );
+    }
+
+    /**
+     * Build the XeChain for an authenticated identity.
+     * @param identity Authenticated identity
+     * @return XeSource chain
+     * @throws IOException If fails
+     */
+    private XeSource chain(final Identity identity) throws IOException {
+        return new XeChain(
+            new XeDirectives(
+                new Directives()
+                    .add("identity")
+                    .add("urn").set(identity.urn()).up()
+                    .add("name").set(
+                        identity.properties().getOrDefault("name", "unknown")
+                    ).up()
+                    .add("photo").set(
+                        identity.properties().getOrDefault(
+                            "picture",
+                            "/images/pomegranate.svg"
+                        )
+                    ).up()
+                    .up()
+            ),
+            new XeAppend(
+                "token",
+                this.base.user(URN.create(identity.urn())).token()
+            ),
+            new XeLink("menu:home", "/"),
+            new XeLink("menu:counters", "/counters"),
+            new XeLink("menu:locks", "/k"),
+            new XeLink("user:refresh", "/u/refresh")
         );
     }
 }

--- a/src/main/java/co/stateful/web/TkCounters.java
+++ b/src/main/java/co/stateful/web/TkCounters.java
@@ -64,8 +64,7 @@ public final class TkCounters implements Take {
             new XeLink("add", "./add"),
             new XeSource() {
                 @Override
-                public Iterable<Directive> toXembly()
-                    throws IOException {
+                public Iterable<Directive> toXembly() throws IOException {
                     return new XeChain(
                         new TkAuthenticated(TkCounters.this.base).source(req),
                         new XeLink("takes:logout", "/?PsByFlag=PsLogout")

--- a/src/main/java/co/stateful/web/TkError.java
+++ b/src/main/java/co/stateful/web/TkError.java
@@ -50,8 +50,7 @@ public final class TkError implements Take {
                 req,
                 new XeSource() {
                     @Override
-                    public Iterable<Directive> toXembly()
-                        throws IOException {
+                    public Iterable<Directive> toXembly() throws IOException {
                         return new XeChain(
                             new TkAuthenticated(TkError.this.base).source(req),
                             new XeLink("takes:logout", "/?PsByFlag=PsLogout")

--- a/src/main/java/co/stateful/web/TkHome.java
+++ b/src/main/java/co/stateful/web/TkHome.java
@@ -60,8 +60,7 @@ public final class TkHome implements Take {
             ),
             new XeSource() {
                 @Override
-                public Iterable<Directive> toXembly()
-                    throws IOException {
+                public Iterable<Directive> toXembly() throws IOException {
                     return new XeChain(
                         new TkAuthenticated(TkHome.this.base).source(req),
                         new XeLink("takes:logout", "/?PsByFlag=PsLogout")

--- a/src/main/java/co/stateful/web/TkLocks.java
+++ b/src/main/java/co/stateful/web/TkLocks.java
@@ -67,8 +67,7 @@ public final class TkLocks implements Take {
             new XeLink("unlock", "/k/unlock"),
             new XeSource() {
                 @Override
-                public Iterable<Directive> toXembly()
-                    throws IOException {
+                public Iterable<Directive> toXembly() throws IOException {
                     return new XeChain(
                         new TkAuthenticated(TkLocks.this.base).source(req),
                         new XeLink("takes:logout", "/?PsByFlag=PsLogout")

--- a/src/main/java/co/stateful/web/package-info.java
+++ b/src/main/java/co/stateful/web/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Web layer based on Takes framework.
- *
  * @since 2.0
  */
 package co.stateful.web;

--- a/src/test/java/co/stateful/core/DefaultUserITCase.java
+++ b/src/test/java/co/stateful/core/DefaultUserITCase.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Integration case for {@link DefaultUser}.
- *
  * @since 0.1
  */
 final class DefaultUserITCase {
@@ -45,5 +44,4 @@ final class DefaultUserITCase {
             )
         );
     }
-
 }

--- a/src/test/java/co/stateful/core/DyCounterITCase.java
+++ b/src/test/java/co/stateful/core/DyCounterITCase.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Integration case for {@link DyCounter}.
- *
  * @since 0.1
  */
 final class DyCounterITCase {
@@ -57,7 +56,6 @@ final class DyCounterITCase {
      * @throws Exception If some problem inside
      */
     @Test
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void incrementAndSetInThreads() throws Exception {
         final Counters counters = new DefaultUser(
             new URN("urn:test:78833")
@@ -81,5 +79,4 @@ final class DyCounterITCase {
             Matchers.hasSize(20)
         );
     }
-
 }

--- a/src/test/java/co/stateful/core/DyCountersITCase.java
+++ b/src/test/java/co/stateful/core/DyCountersITCase.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Integration case for {@link DyCounters}.
- *
  * @since 0.1
  */
 final class DyCountersITCase {
@@ -41,5 +40,4 @@ final class DyCountersITCase {
             Matchers.emptyIterable()
         );
     }
-
 }

--- a/src/test/java/co/stateful/core/DyLocksITCase.java
+++ b/src/test/java/co/stateful/core/DyLocksITCase.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Integration case for {@link DyLocks}.
- *
  * @since 0.1
  */
 final class DyLocksITCase {
@@ -79,5 +78,4 @@ final class DyLocksITCase {
             Matchers.equalTo("")
         );
     }
-
 }

--- a/src/test/java/co/stateful/core/package-info.java
+++ b/src/test/java/co/stateful/core/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Core, tests.
- *
  * @since 0.1
  */
 package co.stateful.core;

--- a/src/test/java/co/stateful/fake/FkUser.java
+++ b/src/test/java/co/stateful/fake/FkUser.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public final class FkUser implements User {
 
     /**
-     * Token.
+     * Token, generated lazily on first read and resettable via refresh.
      */
     private final AtomicReference<String> tkn;
 
@@ -43,7 +43,7 @@ public final class FkUser implements User {
      * Ctor.
      */
     public FkUser() {
-        this(new FkCounters(), new FkLocks());
+        this(new FkCounters(), new FkLocks(), new AtomicReference<>());
     }
 
     /**
@@ -52,9 +52,20 @@ public final class FkUser implements User {
      * @param locks Locks
      */
     public FkUser(final Counters counters, final Locks locks) {
-        this.tkn = new AtomicReference<>(UUID.randomUUID().toString());
+        this(counters, locks, new AtomicReference<>());
+    }
+
+    /**
+     * Ctor that stores all dependencies as-is.
+     * @param counters Counters
+     * @param locks Locks
+     * @param token Initial token holder; empty value means lazy-generate
+     */
+    private FkUser(final Counters counters, final Locks locks,
+        final AtomicReference<String> token) {
         this.ctrs = counters;
         this.lcks = locks;
+        this.tkn = token;
     }
 
     @Override
@@ -64,7 +75,17 @@ public final class FkUser implements User {
 
     @Override
     public String token() {
-        return this.tkn.get();
+        return this.tkn.updateAndGet(
+            prev -> {
+                final String value;
+                if (prev == null) {
+                    value = UUID.randomUUID().toString();
+                } else {
+                    value = prev;
+                }
+                return value;
+            }
+        );
     }
 
     @Override

--- a/src/test/java/co/stateful/fake/package-info.java
+++ b/src/test/java/co/stateful/fake/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Fake objects for testing.
- *
  * @since 2.0
  */
 package co.stateful.fake;

--- a/src/test/java/co/stateful/package-info.java
+++ b/src/test/java/co/stateful/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * App, tests.
- *
  * @since 0.1
  */
 package co.stateful;

--- a/src/test/java/co/stateful/quota/RtQuotaTest.java
+++ b/src/test/java/co/stateful/quota/RtQuotaTest.java
@@ -5,6 +5,9 @@
 package co.stateful.quota;
 
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.Statement;
+import javax.sql.DataSource;
 import org.h2.jdbcx.JdbcDataSource;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -12,7 +15,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link RtQuota}.
- *
  * @since 2.0
  */
 final class RtQuotaTest {
@@ -21,6 +23,7 @@ final class RtQuotaTest {
     void blocksAfterMaximumRequests() throws Exception {
         final JdbcDataSource src = new JdbcDataSource();
         src.setURL("jdbc:h2:mem:test-block;DB_CLOSE_DELAY=-1");
+        RtQuotaTest.prepare(src);
         final Quota quota = new RtQuota(src, 3);
         final Quota user = quota.into("urn:test:1");
         user.use("a");
@@ -42,13 +45,14 @@ final class RtQuotaTest {
     void allowsRequestsFromDifferentUsers() throws Exception {
         final JdbcDataSource src = new JdbcDataSource();
         src.setURL("jdbc:h2:mem:test-users;DB_CLOSE_DELAY=-1");
+        RtQuotaTest.prepare(src);
         final Quota quota = new RtQuota(src, 2);
-        final Quota user1 = quota.into("urn:test:1");
-        final Quota user2 = quota.into("urn:test:2");
-        user1.use("op");
-        user1.use("op");
-        user2.use("op");
-        user2.use("op");
+        final Quota alice = quota.into("urn:test:1");
+        final Quota bob = quota.into("urn:test:2");
+        alice.use("op");
+        alice.use("op");
+        bob.use("op");
+        bob.use("op");
         MatcherAssert.assertThat(
             "Different users should have independent limits",
             true,
@@ -60,6 +64,7 @@ final class RtQuotaTest {
     void doesNotThrowWhenBelowLimit() throws Exception {
         final JdbcDataSource src = new JdbcDataSource();
         src.setURL("jdbc:h2:mem:test-below;DB_CLOSE_DELAY=-1");
+        RtQuotaTest.prepare(src);
         final Quota quota = new RtQuota(src, 300);
         final Quota user = quota.into("urn:test:1");
         for (int idx = 0; idx < 300; ++idx) {
@@ -70,5 +75,19 @@ final class RtQuotaTest {
             true,
             Matchers.is(true)
         );
+    }
+
+    /**
+     * Initialize the rate-limit tracking table on the test data source.
+     * @param src Data source to prepare
+     * @throws Exception If the schema cannot be created
+     */
+    private static void prepare(final DataSource src) throws Exception {
+        try (
+            Connection conn = src.getConnection();
+            Statement stmt = conn.createStatement()
+        ) {
+            stmt.execute(RtQuota.SCHEMA);
+        }
     }
 }

--- a/src/test/java/co/stateful/quota/package-info.java
+++ b/src/test/java/co/stateful/quota/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Quota tests.
- *
  * @since 2.0
  */
 package co.stateful.quota;

--- a/src/test/java/co/stateful/web/RsPageTest.java
+++ b/src/test/java/co/stateful/web/RsPageTest.java
@@ -16,7 +16,6 @@ import org.takes.rs.xe.XeAppend;
 
 /**
  * Test case for {@link RsPage}.
- *
  * @since 2.0
  */
 final class RsPageTest {

--- a/src/test/java/co/stateful/web/TkAppFallbackTest.java
+++ b/src/test/java/co/stateful/web/TkAppFallbackTest.java
@@ -15,7 +15,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkAppFallback}.
- *
  * @since 2.0
  */
 final class TkAppFallbackTest {

--- a/src/test/java/co/stateful/web/TkAppITCase.java
+++ b/src/test/java/co/stateful/web/TkAppITCase.java
@@ -16,13 +16,11 @@ import org.takes.http.FtRemote;
 
 /**
  * Integration test case for {@link TkApp}.
- *
  * @since 2.0
  */
 final class TkAppITCase {
 
     @Test
-    @SuppressWarnings("PMD.UnitTestShouldIncludeAssert")
     void rendersHomePageWithDocumentation() throws Exception {
         new FtRemote(
             new TkApp(new QtBase(new DefaultBase(), Quota.UNLIMITED))
@@ -39,7 +37,6 @@ final class TkAppITCase {
     }
 
     @Test
-    @SuppressWarnings("PMD.UnitTestShouldIncludeAssert")
     void servesStaticResources() throws Exception {
         new FtRemote(
             new TkApp(new QtBase(new DefaultBase(), Quota.UNLIMITED))

--- a/src/test/java/co/stateful/web/TkAppTest.java
+++ b/src/test/java/co/stateful/web/TkAppTest.java
@@ -16,7 +16,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkApp}.
- *
  * @since 2.0
  */
 final class TkAppTest {

--- a/src/test/java/co/stateful/web/TkAuthenticatedTest.java
+++ b/src/test/java/co/stateful/web/TkAuthenticatedTest.java
@@ -19,7 +19,6 @@ import org.takes.rs.xe.XeChain;
 
 /**
  * Test case for {@link TkAuthenticated}.
- *
  * @since 2.0
  */
 final class TkAuthenticatedTest {

--- a/src/test/java/co/stateful/web/TkCounterAddTest.java
+++ b/src/test/java/co/stateful/web/TkCounterAddTest.java
@@ -16,18 +16,15 @@ import org.takes.rq.RqWithBody;
 
 /**
  * Test case for {@link TkCounterAdd}.
- *
  * @since 2.0
  */
 final class TkCounterAddTest {
 
     @Test
     void createsCounter() {
-        final FkBase base = new FkBase();
-        final URN urn = URN.create("urn:test:1");
         Assertions.assertThrows(
             RsForward.class,
-            () -> new TkCounterAdd(base).act(
+            () -> new TkCounterAdd(new FkBase()).act(
                 new RqAuth(
                     new RqWithBody(
                         new RqFake(
@@ -40,7 +37,7 @@ final class TkCounterAddTest {
                         ),
                         "name=counter123"
                     ),
-                    urn.toString(),
+                    URN.create("urn:test:1").toString(),
                     "Tëst-Üsér-αβγ"
                 )
             ),
@@ -75,7 +72,6 @@ final class TkCounterAddTest {
 
     @Test
     void rejectsTooLongName() {
-        final String name = "a".repeat(64);
         Assertions.assertThrows(
             RsForward.class,
             () -> new TkCounterAdd(new FkBase()).act(
@@ -89,7 +85,7 @@ final class TkCounterAddTest {
                             ),
                             ""
                         ),
-                        String.format("name=%s", name)
+                        String.format("name=%s", "a".repeat(64))
                     ),
                     "urn:test:3",
                     "Námé"

--- a/src/test/java/co/stateful/web/TkCounterDeleteTest.java
+++ b/src/test/java/co/stateful/web/TkCounterDeleteTest.java
@@ -16,7 +16,6 @@ import org.takes.rq.RqFake;
 
 /**
  * Test case for {@link TkCounterDelete}.
- *
  * @since 2.0
  */
 final class TkCounterDeleteTest {

--- a/src/test/java/co/stateful/web/TkCounterIncTest.java
+++ b/src/test/java/co/stateful/web/TkCounterIncTest.java
@@ -19,7 +19,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkCounterInc}.
- *
  * @since 2.0
  */
 final class TkCounterIncTest {

--- a/src/test/java/co/stateful/web/TkCounterSetTest.java
+++ b/src/test/java/co/stateful/web/TkCounterSetTest.java
@@ -18,7 +18,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkCounterSet}.
- *
  * @since 2.0
  */
 final class TkCounterSetTest {

--- a/src/test/java/co/stateful/web/TkCountersTest.java
+++ b/src/test/java/co/stateful/web/TkCountersTest.java
@@ -17,7 +17,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkCounters}.
- *
  * @since 2.0
  */
 final class TkCountersTest {

--- a/src/test/java/co/stateful/web/TkErrorTest.java
+++ b/src/test/java/co/stateful/web/TkErrorTest.java
@@ -18,7 +18,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkError}.
- *
  * @since 2.0
  */
 final class TkErrorTest {

--- a/src/test/java/co/stateful/web/TkHomeTest.java
+++ b/src/test/java/co/stateful/web/TkHomeTest.java
@@ -16,7 +16,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkHome}.
- *
  * @since 2.0
  */
 final class TkHomeTest {

--- a/src/test/java/co/stateful/web/TkLockCreateTest.java
+++ b/src/test/java/co/stateful/web/TkLockCreateTest.java
@@ -20,18 +20,15 @@ import org.takes.rq.RqWithBody;
 
 /**
  * Test case for {@link TkLockCreate}.
- *
  * @since 2.0
  */
 final class TkLockCreateTest {
 
     @Test
     void createsLock() {
-        final FkBase base = new FkBase();
-        final URN urn = URN.create("urn:test:1");
         Assertions.assertThrows(
             RsForward.class,
-            () -> new TkLockCreate(base).act(
+            () -> new TkLockCreate(new FkBase()).act(
                 new RqAuth(
                     new RqWithBody(
                         new RqFake(
@@ -44,7 +41,7 @@ final class TkLockCreateTest {
                         ),
                         "name=mylock&label=mylabel"
                     ),
-                    urn.toString(),
+                    URN.create("urn:test:1").toString(),
                     "Tëst-Üsér"
                 )
             ),

--- a/src/test/java/co/stateful/web/TkLockLabelTest.java
+++ b/src/test/java/co/stateful/web/TkLockLabelTest.java
@@ -16,7 +16,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkLockLabel}.
- *
  * @since 2.0
  */
 final class TkLockLabelTest {

--- a/src/test/java/co/stateful/web/TkLocksTest.java
+++ b/src/test/java/co/stateful/web/TkLocksTest.java
@@ -17,7 +17,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkLocks}.
- *
  * @since 2.0
  */
 final class TkLocksTest {

--- a/src/test/java/co/stateful/web/TkStaticTest.java
+++ b/src/test/java/co/stateful/web/TkStaticTest.java
@@ -15,7 +15,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkStatic}.
- *
  * @since 2.0
  */
 final class TkStaticTest {

--- a/src/test/java/co/stateful/web/TkUnlockTest.java
+++ b/src/test/java/co/stateful/web/TkUnlockTest.java
@@ -19,7 +19,6 @@ import org.takes.rq.RqMethod;
 
 /**
  * Test case for {@link TkUnlock}.
- *
  * @since 2.0
  */
 final class TkUnlockTest {
@@ -96,9 +95,8 @@ final class TkUnlockTest {
     @Test
     void handlesUrlEncodedLabelWithHashAndSlash() throws Exception {
         final FkBase base = new FkBase();
-        final String label = "objectionary/home#376";
         final String name = "rt-repo-objectionary-home";
-        base.user(URN.create("urn:test:4")).locks().lock(name, label);
+        base.user(URN.create("urn:test:4")).locks().lock(name, "objectionary/home#376");
         try {
             new TkUnlock(base).act(
                 new RqAuth(
@@ -121,10 +119,9 @@ final class TkUnlockTest {
 
     @Test
     void handlesNonExistentLockWithLabel() throws Exception {
-        final FkBase base = new FkBase();
         Assertions.assertThrows(
             RsForward.class,
-            () -> new TkUnlock(base).act(
+            () -> new TkUnlock(new FkBase()).act(
                 new RqAuth(
                     new RqFake(
                         RqMethod.GET,

--- a/src/test/java/co/stateful/web/TkUserRefreshTest.java
+++ b/src/test/java/co/stateful/web/TkUserRefreshTest.java
@@ -16,7 +16,6 @@ import org.takes.rq.RqFake;
 
 /**
  * Test case for {@link TkUserRefresh}.
- *
  * @since 2.0
  */
 final class TkUserRefreshTest {

--- a/src/test/java/co/stateful/web/package-info.java
+++ b/src/test/java/co/stateful/web/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Web layer tests.
- *
  * @since 2.0
  */
 package co.stateful.web;


### PR DESCRIPTION
## Summary

- Bumped `qulice-maven-plugin` from **0.25.2** → **0.27.6** in `pom.xml`.
- Fixed every violation reported by the new rule set (114 → 0) without using any `@SuppressWarnings`.
- All 71 existing unit tests still pass.
- `mvn -DskipTests -Pqulice clean verify` is green.

## Notable refactors (constructor cleanups)

The new `ConstructorsCodeFreeCheck` (Checkstyle) and `ProhibitPublicStaticMethods` (PMD) rules forced several non-trivial restructurings to keep behavior intact:

| Class | Change |
| --- | --- |
| `co.stateful.core.DefaultUser` | The per-instance DynamoDB `Region` is now a shared `static final REGION` built once from the manifest. Constructor only assigns the URN. |
| `co.stateful.quota.RtQuota` | The public constructor no longer creates the schema. The DDL is exposed as `public static final String SCHEMA`, and `Entry`/`RtQuotaTest` execute it explicitly. Nested-try depth reduced by extracting `insert`/`purge`/`count` helpers; `ResultSet.next()` return value is checked. |
| `co.stateful.web.RsPage` | Content negotiation moved into a `private static Negotiated implements Response`, so the public constructor only does `super(new Negotiated(...))`. Manifest reads moved to `static final` fields. |
| `co.stateful.web.TkApp` | Routing graph is built inline via constructor expressions (no helper methods). Counter dispatch helpers replaced with lambdas + a single private static helper. |
| `co.stateful.web.TkAppAuth` / `TkAppFallback` | Helper builder methods inlined; manifest-derived values moved to `static final` fields (cookie codec, GitHub provider, tester). |
| `co.stateful.web.TkAuthenticated` | Long lambda body extracted into a `chain()` method to satisfy `LambdaBodyLengthCheck`. |
| `co.stateful.fake.FkUser` (test fake) | Token now constructor-injected as an empty `AtomicReference` and lazily seeded on first read via `updateAndGet`, to satisfy both `ConstructorsCodeFreeCheck` and `ConstructorShouldDoInitialization` (see contradiction below). |

## Smaller fixes

- Removed dangling Javadoc + reordered `MAX_RPM` in `Entry`.
- Removed unnecessary local variables in 3 test files.
- Tightened fluent-call layout in `DefaultUser` and `DyLocks` (qulice wants the `.with(` / `.put(` / etc. that opens a multi-line block to be attached to the previous line).
- Removed empty Javadoc lines before tag clauses for single-paragraph descriptions across 48 files.
- Removed empty lines before closing braces in 11 files.
- Renamed `user1`/`user2` → `alice`/`bob` in `RtQuotaTest` to satisfy `LocalFinalVariableNameCheck`.
- Removed 4 obsolete `@SuppressWarnings` annotations that qulice 0.27.6 flagged as `UnnecessaryWarningSuppression`.
- Removed redundant `@throws HttpException` from `RqUser#user()` (HttpException extends IOException, already declared).
- Inlined `throws IOException` declarations onto a single line in 4 anonymous `XeSource` classes to satisfy `MethodDeclarationLengthCheck`.

## Contradiction in qulice 0.27.6 — bug report needed upstream

While fixing violations I hit a hard contradiction between two qulice rules that I could not file directly (my GitHub MCP scope only allows `sttc/stateful`):

> **Checkstyle `ConstructorsCodeFreeCheck`** — "Constructor must not contain method calls."
> **PMD `ConstructorShouldDoInitialization`** — "Avoid doing field initialization outside constructor" (fires whenever an instance field has an initializer **and** the class declares at least one constructor).

For any final instance field whose initial value cannot be obtained without invoking a method (e.g. `UUID.randomUUID().toString()`, `Manifests.read(...)`), the two rules cannot both be satisfied — every solution violates exactly one of them. The only escape is to take all such values as constructor parameters and force the call sites to invoke the methods, which just relocates the same paradox to the caller.

I worked around it in `FkUser` by lazy-seeding the token via `AtomicReference.updateAndGet` on first read, but a proper fix would be either:
- Relax `ConstructorsCodeFreeCheck` to allow a method-call result assigned to a final field, **or**
- Relax `ConstructorShouldDoInitialization` to allow field initializers even when the class declares constructors (the standard Java idiom).

Please file the above against https://github.com/yegor256/qulice — I would have done it myself, but my session's MCP token is restricted to this repo.

## Test plan

- [x] `mvn -DskipTests -Pqulice clean verify` — BUILD SUCCESS, 0 violations.
- [x] `mvn -DskipITs test` — 71 tests run, 0 failures, 0 errors, 0 skipped.
- [ ] CI run on this PR.

https://claude.ai/code/session_01V4ezh4zd22EVhMeVG8yw3Z