### PR TITLE
fix: #224 enforce strict cap in lock and counter creation

### DIFF
--- a/src/main/java/co/stateful/web/TkCounterAdd.java
+++ b/src/main/java/co/stateful/web/TkCounterAdd.java
@@ -51,7 +51,7 @@ public final class TkCounterAdd implements Take {
             );
         }
         final RqUser user = new RqUser(req, this.base);
-        if (Iterables.size(user.user().counters().names()) > Counters.MAX) {
+        if (Iterables.size(user.user().counters().names()) >= Counters.MAX) {
             throw new RsForward(
                 new RsFlash("too many counters in your account"),
                 "/counters"

--- a/src/main/java/co/stateful/web/TkLockCreate.java
+++ b/src/main/java/co/stateful/web/TkLockCreate.java
@@ -74,7 +74,7 @@ public final class TkLockCreate implements Take {
             );
         }
         final RqUser user = new RqUser(req, this.base);
-        if (user.user().locks().names().size() > Locks.MAX) {
+        if (user.user().locks().names().size() >= Locks.MAX) {
             throw new RsForward(
                 new RsFlash("too many locks in your account"),
                 "/k"


### PR DESCRIPTION
Issue #224 reports that `TkLockCreate` and `TkCounterAdd` both compare the current account size against `Locks.MAX` and `Counters.MAX` with strict-greater-than, so a user already holding exactly `MAX` entries slips one past the check and the account ends with `MAX + 1`. The fix changes both comparisons to `>=`, so the new entry is rejected when the user is already at the documented ceiling and the existing flash message stays accurate.

Visible effect: a tenant at `Locks.MAX` who tries to add another lock now receives the same `RsForward` flash already shown when the cap is breached, instead of silently being allowed to push the count to 4097; the same holds for counters at the cap of 64.

Tests run locally on the fix branch with `mvn --batch-mode test -Dtest='TkLockCreateTest,TkCounterAddTest'` — `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0`. The wider `mvn clean install -Pqulice` is red on `TkAppTest.servesCssWithCorrectContentType` and `TkStaticTest`, but the same failures reproduce on a clean `master` checkout on this Java 21 environment because the `sass-maven-plugin` cannot open `sun.nio.ch` under the current module rules, so the breakage is pre-existing and unrelated to this change.

Closes #224
