### PR TITLE
compare X-Sttc-Token in constant time

### DIFF
--- a/src/main/java/co/stateful/web/PsHeader.java
+++ b/src/main/java/co/stateful/web/PsHeader.java
@@ -9,6 +9,8 @@ import co.stateful.spi.User;
 import com.jcabi.urn.URN;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Iterator;
 import org.takes.HttpException;
 import org.takes.Request;
@@ -91,7 +93,12 @@ public final class PsHeader implements Pass {
         if (!user.exists()) {
             throw new HttpException(HttpURLConnection.HTTP_UNAUTHORIZED);
         }
-        if (!user.token().equals(token)) {
+        if (
+            !MessageDigest.isEqual(
+                user.token().getBytes(StandardCharsets.UTF_8),
+                token.getBytes(StandardCharsets.UTF_8)
+            )
+        ) {
             throw new HttpException(HttpURLConnection.HTTP_UNAUTHORIZED);
         }
         return new Opt.Single<>(


### PR DESCRIPTION
`PsHeader.auth` checked the supplied `X-Sttc-Token` header against the stored user token with `String#equals`, which short-circuits at the first mismatching character and lets a network attacker recover the secret byte by byte by measuring response latency. The token is the only credential a non-cookie client presents, so the timing leak compromises every counter, lock, and quota of the affected account.

After this change the comparison runs through `MessageDigest.isEqual` over the UTF-8 bytes of both strings, so the wall-clock cost of the check no longer depends on where the mismatch falls. Header-based authentication continues to reject mismatched tokens with HTTP 401 and to admit matching ones with the same `Identity.Simple` it produced before.

Locally I ran ``mvn --batch-mode install -Pqulice -Dmaven.test.skip=true`` (BUILD SUCCESS) and ``mvn --batch-mode test -Dtest=TkAppAuthTest`` (3 tests passed, 0 failed). The wider `mvn test` run hits pre-existing errors in `RsPageTest`, `TkCountersTest`, `TkErrorTest`, `TkHomeTest`, `TkLocksTest`, and the `Dy*ITCase` integration tests, all of which fail identically on `master` before this branch.

Closes #248